### PR TITLE
[Feat] Separates client from server functionality

### DIFF
--- a/components/CreateSubscriberButton.tsx
+++ b/components/CreateSubscriberButton.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { ChangeEvent, useState } from "react";
 import { Button, Modal, Form, Input } from "@canonical/react-components";
-import { WEBUI_ENDPOINT } from "@/public/sdcoreConfig";
 
 import { useSubscriber } from "@/hooks/useSubscriber";
 
@@ -19,7 +18,6 @@ export default function CreateSubscriber(props: Props) {
   const [key, setKey] = useState<string>("");
   const [sequenceNumber, setSequenceNumber] = useState<string>("");
   const { handleSubscriber } = useSubscriber(
-    WEBUI_ENDPOINT,
     imsi,
     opc,
     key,

--- a/components/DeleteSubscriberButton.tsx
+++ b/components/DeleteSubscriberButton.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { Button } from "@canonical/react-components";
-import { WEBUI_ENDPOINT, STATIC_DEVICE_GROUP_DATA, STATIC_NETWORK_SLICE_DATA } from "@/public/sdcoreConfig";
 import { useState } from "react";
 
 type Props = {
@@ -21,62 +20,26 @@ export default function DeleteSubscriberButton(props: Props) {
 
   const handleDeleteSubscriber = async () => {
     setDeleting(true);
-
-    const deleteSubscriber = async () => {
-      try {
-        const response = await fetch(
-          `${WEBUI_ENDPOINT}/api/subscriber/imsi-${props.imsi}`,
-          {
-            method: "DELETE",
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error("Failed to delete subscriber");
-        }
-
-        const data = await response.json();
-        console.log(data);
-      } catch (error) {
-        console.error(error);
+  
+    try {
+      const response = await fetch(`/api/deleteSubscriber?imsi=${props.imsi}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ currentSubscribers: props.currentSubscribers }),
+      });
+  
+      if (!response.ok) {
+        throw new Error("Failed to delete subscriber");
       }
-    };
-
-    const removeSubcriberFromDeviceGroup = async () => {
-      try {
-        const response = await fetch(
-          `${WEBUI_ENDPOINT}/config/v1/device-group/${STATIC_NETWORK_SLICE_DATA["site-device-group"][0]}`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              imsis: [
-                ...getFilteredSubscribers(props.currentSubscribers, props.imsi),
-              ],
-              ...STATIC_DEVICE_GROUP_DATA,
-            }),
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error(
-            `Failed to add subscriber to device group. Error code : ${response.status}`
-          );
-        }
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
-    await deleteSubscriber();
-    await removeSubcriberFromDeviceGroup();
-    setDeleting(false);
-    props.refreshHandler();
+  
+      setDeleting(false);
+      props.refreshHandler();
+    } catch (error) {
+      console.error(error);
+      setDeleting(false);
+    }
   };
 
   return (

--- a/components/EditSubscriber.tsx
+++ b/components/EditSubscriber.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { Modal, Form, Input, Button } from "@canonical/react-components";
 import React, { ReactNode, useState, ChangeEvent } from "react";
-import { WEBUI_ENDPOINT } from "@/public/sdcoreConfig";
 import { useSubscriber } from "@/hooks/useSubscriber";
 
 type Props = {
@@ -12,13 +11,11 @@ type Props = {
 
 export default function EditSubscriber(props: Props): ReactNode {
   const [modalOpen, setModalOpen] = useState<boolean>(false);
-  const [imsi, setImsi] = useState<string>("");
   const [opc, setOpc] = useState<string>("");
   const [key, setKey] = useState<string>("");
   const [sequenceNumber, setSequenceNumber] = useState<string>("");
   const closeHandler = () => setModalOpen(false);
   const { handleSubscriber } = useSubscriber(
-    WEBUI_ENDPOINT,
     props.imsi,
     opc,
     key,

--- a/components/NetworkConfiguration.tsx
+++ b/components/NetworkConfiguration.tsx
@@ -1,82 +1,38 @@
 "use client";
 import { useState } from "react";
 import { Input, Button } from "@canonical/react-components";
-import {
-  WEBUI_ENDPOINT,
-  STATIC_NETWORK_SLICE_DATA,
-  NETWORK_SLICE_NAME,
-} from "@/public/sdcoreConfig";
-
-export type NetworkSliceData = {
-  "slice-id": {
-    sst: number;
-    sd: string;
-  };
-  "site-device-group": string[];
-  "site-info": {
-    "site-name": string;
-    plmn: {
-      mcc: string;
-      mnc: string;
-    };
-    gNodeBs: {
-      name: string;
-      tac: string;
-    }[];
-    upf: {
-      "upf-name": string;
-      "upf-port": string;
-    };
-  };
-};
 
 export default function NetworkConfiguration() {
   const [mcc, setMcc] = useState<string>("");
   const [mnc, setMnc] = useState<string>("");
 
   const handleMccChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.target;
-    setMcc(value);
+    setMcc(e.target.value);
   };
 
   const handleMncChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.target;
-    setMnc(value);
-  };
-
-  const createNetworkSliceWithDeviceGroup = async () => {
-    const url = `${WEBUI_ENDPOINT}/config/v1/network-slice/${NETWORK_SLICE_NAME}`;
-    const headers = {
-      "Content-Type": "application/json",
-    };
-
-    const networkSliceData: NetworkSliceData = {
-      ...STATIC_NETWORK_SLICE_DATA,
-      "site-info": {
-        ...STATIC_NETWORK_SLICE_DATA["site-info"],
-        plmn: { mcc: mcc, mnc: mnc },
-      },
-    };
-
-    try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(networkSliceData),
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `Error creating network. Error code: ${response.status}`
-        );
-      }
-    } catch (error) {
-      console.error(error);
-    }
+    setMnc(e.target.value);
   };
 
   const handleSave = async () => {
-    await createNetworkSliceWithDeviceGroup();
+    const plmnData = { mcc, mnc };
+
+    try {
+      const response = await fetch('/api/createNetworkSlice', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(plmnData),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Error creating network. Error code: ${response.status}`);
+      }
+
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/components/SubscriberTable.tsx
+++ b/components/SubscriberTable.tsx
@@ -13,7 +13,6 @@ import {
 
 import { SlRefresh } from "react-icons/sl";
 
-import { WEBUI_ENDPOINT } from "@/public/sdcoreConfig";
 
 export type Subscriber = {
   plmnID: string;
@@ -35,23 +34,14 @@ export default function SubscriberTable() {
   useEffect(() => {
     const fetchSubscribers = async () => {
       setLoading(true);
-
-      const headers = {
-        "Content-Type": "application/json",
-      };
-
+    
       try {
-        const response = await fetch(`${WEBUI_ENDPOINT}/api/subscriber`, {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
-
+        const response = await fetch(`/api/getSubscribers`);
+    
         if (!response.ok) {
           throw new Error("Failed to fetch subscribers");
         }
-
+    
         const data = await response.json();
         setSubscribers(data);
       } catch (error) {
@@ -61,6 +51,7 @@ export default function SubscriberTable() {
         setCreateEnabled(false);
       }
     };
+    
 
     fetchSubscribers();
   }, [refresh]);

--- a/components/SubscriberTable.tsx
+++ b/components/SubscriberTable.tsx
@@ -41,7 +41,6 @@ export default function SubscriberTable() {
         if (!response.ok) {
           throw new Error("Failed to fetch subscribers");
         }
-    
         const data = await response.json();
         setSubscribers(data);
       } catch (error) {

--- a/config/sdcoreConfig.ts
+++ b/config/sdcoreConfig.ts
@@ -1,4 +1,5 @@
-const WEBUI_ENDPOINT: string = "http://3.90.228.4:8543";
+
+const WEBUI_ENDPOINT = process.env.WEBUI_ENDPOINT || 'http://localhost:3000';
 
 const STATIC_SUSBCRIBER_DATA = {
   plmnID: "20893",
@@ -30,24 +31,25 @@ const NETWORK_SLICE_NAME: string = "default";
 
 const STATIC_NETWORK_SLICE_DATA = {
   "slice-id": {
-    sst: 1,
-    sd: "010203",
+    "sst": "1",
+    "sd": "010203",
   },
   "site-device-group": ["cows"],
   "site-info": {
     "site-name": "demo",
-    gNodeBs: [
+    "gNodeBs": [
       {
-        name: "demo-gnb1",
-        tac: "1",
+        "name": "demo-gnb1",
+        "tac": 1,
       },
     ],
-    upf: {
-      "upf-name": "upf",
-      "upf-port": "8805",
+    "upf": {
+      "upf-name": process.env.UPF_HOSTNAME || "upf",
+      "upf-port": process.env.UPF_PORT || "8805",
     },
   },
 };
+
 
 export {
   WEBUI_ENDPOINT,

--- a/hooks/useSubscriber.tsx
+++ b/hooks/useSubscriber.tsx
@@ -1,78 +1,35 @@
 import { useCallback } from "react";
-import {
-  STATIC_SUSBCRIBER_DATA,
-  STATIC_DEVICE_GROUP_DATA,
-  STATIC_NETWORK_SLICE_DATA,
-} from "@/public/sdcoreConfig";
 
 export const useSubscriber = (
-  webuiEndpoint: string,
   imsi: string,
   opc: string,
   key: string,
   sequenceNumber: string,
   currentSubscribers: string[]
 ) => {
-  const createSubscriber = useCallback(async () => {
-    try {
-      const response = await fetch(
-        `${webuiEndpoint}/api/subscriber/imsi-${imsi}`,
-        {
-          method: "POST",
-          // mode: "no-cors", FIXME: Remove when webui API is fixed.
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            UeId: imsi,
-            plmnId: STATIC_SUSBCRIBER_DATA.plmnID,
-            opc: opc,
-            key: key,
-            sequenceNumber: sequenceNumber,
-          }),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(
-          `Failed to create subscriber. Error code : ${response.status}`
-        );
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  }, [webuiEndpoint, imsi, opc, key, sequenceNumber]);
-
-  const addSubscriberToDeviceGroup = useCallback(async () => {
-    try {
-      const response = await fetch(
-        `${webuiEndpoint}/config/v1/device-group/${STATIC_NETWORK_SLICE_DATA["site-device-group"][0]}`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            imsis: [...currentSubscribers, imsi],
-            ...STATIC_DEVICE_GROUP_DATA,
-          }),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(
-          `Failed to add subscriber to device group. Error code : ${response.status}`
-        );
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  }, [webuiEndpoint, imsi, currentSubscribers]);
-
   const handleSubscriber = useCallback(async () => {
-    await createSubscriber();
-    await addSubscriberToDeviceGroup();
-  }, [createSubscriber, addSubscriberToDeviceGroup]);
+    try {
+      const response = await fetch("/api/createSubscriber", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          imsi,
+          opc,
+          key,
+          sequenceNumber,
+          currentSubscribers
+        }),
+      });
 
-  return { createSubscriber, addSubscriberToDeviceGroup, handleSubscriber };
+      if (!response.ok) {
+        throw new Error(`Failed to create subscriber. Error code: ${response.status}`);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }, [imsi, opc, key, sequenceNumber, currentSubscribers]);
+
+  return { handleSubscriber };
 };

--- a/pages/api/createNetworkSlice.ts
+++ b/pages/api/createNetworkSlice.ts
@@ -1,0 +1,64 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import {
+    WEBUI_ENDPOINT,
+    NETWORK_SLICE_NAME,
+    STATIC_NETWORK_SLICE_DATA,
+  } from "@/config/sdcoreConfig";
+
+export type NetworkSliceData = {
+    "slice-id": {
+      sst: string;
+      sd: string;
+    };
+    "site-device-group": string[];
+    "site-info": {
+      "site-name": string;
+      "plmn": {
+        "mcc": string;
+        "mnc": string;
+      };
+      "gNodeBs": {
+        "name": string;
+        "tac": number;
+      }[];
+      "upf": {
+        "upf-name": string;
+        "upf-port": string;
+      };
+    };
+  };
+  
+
+export default async function createNetworkSlice(req: NextApiRequest, res: NextApiResponse) {
+  const { mcc, mnc } = req.body;
+
+  const url = `${WEBUI_ENDPOINT}/config/v1/network-slice/${NETWORK_SLICE_NAME}`;
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  const networkSliceData: NetworkSliceData = {
+      ...STATIC_NETWORK_SLICE_DATA,
+      "site-info": {
+        ...STATIC_NETWORK_SLICE_DATA["site-info"],
+        plmn: { mcc: mcc, mnc: mnc },
+      },
+    };
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(networkSliceData),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error creating network. Error code: ${response.status}`);
+    }
+
+    res.status(200).json({ message: "Network created successfully" });
+  } catch (error) {
+    console.error('Error details:', error);
+    res.status(500).json({ error: 'An error occurred while creating the network' });
+  }
+}

--- a/pages/api/createSubscriber.ts
+++ b/pages/api/createSubscriber.ts
@@ -1,0 +1,54 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import {
+  WEBUI_ENDPOINT,
+  STATIC_SUSBCRIBER_DATA,
+  STATIC_DEVICE_GROUP_DATA,
+  STATIC_NETWORK_SLICE_DATA,
+} from "@/config/sdcoreConfig";
+
+export default async function createSubscriber(req: NextApiRequest, res: NextApiResponse) {
+  const { imsi, opc, key, sequenceNumber, currentSubscribers } = req.body;
+
+  try {
+    const response = await fetch(`${WEBUI_ENDPOINT}/api/subscriber/imsi-${imsi}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        UeId: imsi,
+        plmnId: STATIC_SUSBCRIBER_DATA.plmnID,
+        opc: opc,
+        key: key,
+        sequenceNumber: sequenceNumber,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to create subscriber. Error code : ${response.status}`);
+    }
+
+    const responseDeviceGroup = await fetch(
+      `${WEBUI_ENDPOINT}/config/v1/device-group/${STATIC_NETWORK_SLICE_DATA["site-device-group"][0]}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          imsis: [...currentSubscribers, imsi],
+          ...STATIC_DEVICE_GROUP_DATA,
+        }),
+      }
+    );
+
+    if (!responseDeviceGroup.ok) {
+      throw new Error(`Failed to add subscriber to device group. Error code : ${responseDeviceGroup.status}`);
+    }
+
+    res.status(200).send("Subscriber created successfully");
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "An error occurred while creating the subscriber" });
+  }
+}

--- a/pages/api/deleteSubscriber.ts
+++ b/pages/api/deleteSubscriber.ts
@@ -1,0 +1,50 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import {
+    WEBUI_ENDPOINT,
+    STATIC_DEVICE_GROUP_DATA,
+    STATIC_NETWORK_SLICE_DATA,
+  } from "@/config/sdcoreConfig";
+
+export default async function deleteSubscriber(req: NextApiRequest, res: NextApiResponse) {
+  const imsi = req.query.imsi as string;
+
+  const getFilteredSubscribers = (imsiList: string[], imsiToRemove: string): string[] => {
+    return imsiList.filter((imsi) => imsi !== imsiToRemove);
+  };
+
+  try {
+    const response = await fetch(`${WEBUI_ENDPOINT}/api/subscriber/imsi-${imsi}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to delete subscriber");
+    }
+
+    const responseRemove = await fetch(
+      `${WEBUI_ENDPOINT}/config/v1/device-group/${STATIC_NETWORK_SLICE_DATA["site-device-group"][0]}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          imsis: [...getFilteredSubscribers(req.body.currentSubscribers, imsi)],
+          ...STATIC_DEVICE_GROUP_DATA,
+        }),
+      }
+    );
+
+    if (!responseRemove.ok) {
+      throw new Error(`Failed to add subscriber to device group. Error code : ${responseRemove.status}`);
+    }
+
+    res.status(200).send("Subscriber deleted successfully");
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "An error occurred while deleting the subscriber" });
+  }
+}

--- a/pages/api/getSubscribers.ts
+++ b/pages/api/getSubscribers.ts
@@ -1,0 +1,25 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import {
+  WEBUI_ENDPOINT,
+} from "@/config/sdcoreConfig";
+
+export default async function getSubscribers(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const response = await fetch(`${WEBUI_ENDPOINT}/api/subscriber`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch subscribers");
+    }
+
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "An error occurred while fetching subscribers" });
+  }
+}


### PR DESCRIPTION
# Description

## Summary

This implements client/server side separation. The main idea is that the browser should not communicate directly with webui, both for security and ease-of-life reasons. The client side now only communicates with the server side and the server side has the ability to communicate with `webui`.

## Config
The following environment variables now need to be set for running the server:
- WEBUI_ENDPOINT
- UPF_HOSTNAME
- UPF_PORT

Those as well as the rest of the config are now only available to the server.

## Ingress + security

This change will make it possible that the only components that need to be accessible from the outside world is the gui (and not webui).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
