### PR TITLE
[Feat] Adds container image to project

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,0 +1,38 @@
+name: Integration tests
+
+on:
+  workflow_call:
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: canonical/craft-actions/rockcraft-pack@main
+        id: rockcraft
+
+      - name: Install Skopeo
+        run: |
+          sudo snap install skopeo --edge --devmode
+
+      - name: Import the image to Docker registry
+        run: |
+          sudo skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:sdcore-gui:0.1
+
+      - name: Run the image
+        run: |
+          docker run -d -p 3000:3000 sdcore-gui:0.1
+
+      - name: Check if the GUI is successfully running
+        id: test_image
+        run: |
+          sleep 10  # Wait for the container to be ready
+          curl localhost:3000 | grep 'Network Configuration'
+
+      - uses: actions/upload-artifact@v3
+        if: steps.test_image.outcome == 'success'
+        with:
+          name: rock
+          path: ${{ steps.rockcraft.outputs.rock }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,5 +13,6 @@ jobs:
     uses: ./.github/workflows/integration_tests.yaml
 
   publish:
+    if: github.ref_name == 'main'
     needs: integration-tests
     uses: ./.github/workflows/publish.yaml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,16 +1,17 @@
 name: Main branch CI
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   lint-report:
     uses: ./.github/workflows/lint-report.yaml
+  
+  integration-tests:
+    uses: ./.github/workflows/integration_tests.yaml
 
-  build:
-    uses: ./.github/workflows/build.yaml
+  publish:
+    needs: integration-tests
+    uses: ./.github/workflows/publish.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  workflow_call:
+
+jobs:
+
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install skopeo
+        run: |
+          sudo snap install --devmode --channel edge skopeo
+      - name: Install yq
+        run: |
+          sudo snap install yq
+      - uses: actions/download-artifact@v3
+        with:
+          name: rock
+
+      - name: Import and push to github package
+        run: |
+          image_name="$(yq '.name' rockcraft.yaml)"
+          version="$(yq '.version' rockcraft.yaml)"
+          rock_file=$(ls *.rock | tail -n 1)
+          sudo skopeo \
+            --insecure-policy \
+            copy \
+            oci-archive:"${rock_file}" \
+            docker-daemon:"ghcr.io/canonical/${image_name}:${version}"
+          docker push ghcr.io/canonical/${image_name}:${version}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing
 
+
+## Development
+
 To make contributions to this project, make sure you have [`Nodejs 18`](https://nodejs.org/) installed.
 
 1. Clone the repository:
@@ -22,11 +25,11 @@ To make contributions to this project, make sure you have [`Nodejs 18`](https://
 
 4. Run the development server:
 
-```bash
-npm run dev
-```
+   ```bash
+   npm run dev
+   ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to start contributing.
+Open [http://localhost:3000](http://localhost:3000) with your browser to view the changes.
 
 ## Testing
 
@@ -47,3 +50,25 @@ To build the project:
 ```shell
 npm run build
 ```
+
+## Container image
+
+Pack the ROCK
+
+```bash
+rockcraft pack -v
+```
+
+Move the ROCK to Docker's registry
+
+```bash
+sudo skopeo --insecure-policy copy oci-archive:sdcore-gui_0.1_amd64.rock docker-daemon:sdcore-gui:0.1
+```
+
+Run the GUI
+
+```bash
+docker run -p 3000:3000 sdcore-gui:0.1
+```
+
+You will have the GUI available in `http://localhost:3000`.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@
 </div>
 
 Graphical User Interface (GUI) for configuring SD-Core and managing subscribers.
+
+## Usage
+
+```console
+docker pull ghcr.io/canonical/sdcore-gui:0.1
+docker run -it ghcr.io/canonical/sdcore-gui:0.1
+```

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = { output: "standalone" };
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+const nextConfig = {
+  basePath: basePath,
+  assetPrefix: basePath,
+};
 
 module.exports = nextConfig;

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,43 @@
+name: sdcore-gui
+base: ubuntu:22.04
+version: "0.1"
+summary: SD-Core GUI
+description: |
+  A graphical user interface for SD-Core.
+license: Apache-2.0
+platforms:
+  amd64:
+
+services:
+  sdcore-gui:
+    override: replace
+    command: npm run start
+    working-dir: /app
+    startup: enabled
+    environment:
+      WEBUI_ENDPOINT: "http://1.3.4.5:5000"
+      UPF_HOSTNAME: "upf"
+      UPF_PORT: 1111
+
+parts:
+  node:  # FIXME: Node should be installed using `stage-snap`. Bug: https://github.com/canonical/rockcraft/issues/307
+    plugin: nil
+    override-build: |
+      curl -s "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-x64.tar.gz" | tar --strip-components=1 -xzf - -C "${CRAFT_PART_INSTALL}"
+
+  frontend:
+    plugin: nil
+    source: .
+    build-snaps:
+      - node/18/stable
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/app
+      
+      npm ci
+      npm run build
+      
+      cp -r .next ${CRAFT_PART_INSTALL}/app/
+      cp -r node_modules ${CRAFT_PART_INSTALL}/app/
+      cp package*.json ${CRAFT_PART_INSTALL}/app/
+      cp -r public ${CRAFT_PART_INSTALL}/app/
+      cp -r config ${CRAFT_PART_INSTALL}/app/


### PR DESCRIPTION
# Description

The container image used to be maintained independently in [sdcore-gui-rock](https://github.com/canonical/sdcore-gui-rock). This PR moves the rock management to this project instead. This includes both the `rockcraft.yaml` file itself and the CI to publish it.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
