### PR TITLE
[Bug fix] Doesn't use working-dir in pebble layer

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -11,7 +11,7 @@ platforms:
 services:
   sdcore-gui:
     override: replace
-    command: "/bin/bash -c 'cd /app && npm run start'"
+    command: "/bin/bash -c 'cd /app && npm run start'"  # TODO: Use working-dir once it is available in Juju (Ref: https://github.com/canonical/operator/issues/988)
     startup: enabled
     environment:
       WEBUI_ENDPOINT: "http://1.3.4.5:5000"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -11,8 +11,7 @@ platforms:
 services:
   sdcore-gui:
     override: replace
-    command: npm run start
-    working-dir: /app
+    command: "/bin/bash -c 'cd /app && npm run start'"
     startup: enabled
     environment:
       WEBUI_ENDPOINT: "http://1.3.4.5:5000"


### PR DESCRIPTION
# Description

Doesn't use working-dir in pebble layer because the Pebble version that juju uses doesn't support it yet. This should be fixed in Juju 3.1.6

Reference
- https://github.com/canonical/operator/issues/988

Having the pebble layer like it was made the GUI charm crash before being able to ovewrite the pebble layer:

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/./src/charm.py", line 147, in <module>
    main(SDCoreGUIOperatorCharm)
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/venv/ops/main.py", line 439, in main
    framework.reemit()
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/venv/ops/framework.py", line 851, in reemit
    self._reemit()
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/venv/ops/framework.py", line 930, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/./src/charm.py", line 65, in _configure_sdcore_gui
    self._configure_pebble()
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/./src/charm.py", line 112, in _configure_pebble
    plan = self._container.get_plan()
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/venv/ops/model.py", line 1972, in get_plan
    return self._pebble.get_plan()
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/venv/ops/pebble.py", line 1881, in get_plan
    resp = self._request('GET', '/v1/plan', {'format': 'yaml'})
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/venv/ops/pebble.py", line 1560, in _request
    response = self._request_raw(method, path, query, headers, data)
  File "/var/lib/juju/agents/unit-sdcore-gui-0/charm/venv/ops/pebble.py", line 1604, in _request_raw
    raise APIError(body, code, status, message)
ops.pebble.APIError: cannot parse layer "sdcore-gui": yaml: unmarshal errors:
  line 14: field working-dir not found in type plan.Service

```
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
