### PR TITLE
[Feat] Adds build step before integration tests in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,8 +8,12 @@ on:
 jobs:
   lint-report:
     uses: ./.github/workflows/lint-report.yaml
+
+  build:
+    uses: ./.github/workflows/build.yaml
   
   integration-tests:
+    needs: build
     uses: ./.github/workflows/integration_tests.yaml
 
   publish:


### PR DESCRIPTION
# Description

Adds build step before integration tests in CI. This makes it quicker to observe issues with the build and removes the need to set up rockcraft to notice that the project doesn't build.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
