### PR TITLE
[Chore] Removes service from rock

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,16 +8,6 @@ license: Apache-2.0
 platforms:
   amd64:
 
-services:
-  sdcore-gui:
-    override: replace
-    command: "/bin/bash -c 'cd /app && npm run start'"  # TODO: Use working-dir once it is available in Juju (Ref: https://github.com/canonical/operator/issues/988)
-    startup: enabled
-    environment:
-      WEBUI_ENDPOINT: "http://1.3.4.5:5000"
-      UPF_HOSTNAME: "upf"
-      UPF_PORT: 1111
-
 parts:
   node:  # FIXME: Node should be installed using `stage-snap`. Bug: https://github.com/canonical/rockcraft/issues/307
     plugin: nil


### PR DESCRIPTION
# Description

Removes the pebble service from the rockcraft definition. This service will be created by the charm. This will avoid conflicts between the 2 services.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
