### PR TITLE
[Feat] Only renders page content if backend is available

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,19 @@
 "use client";
-import { useState } from "react";
 import Image from "next/image";
-
+import React, { useState, useEffect } from "react";
 import SubscriberTable from "@/components/SubscriberTable";
 
 import canonicalUbuntuLogo from "@/public/Canonical-Ubuntu+logo-2021_RGB_reverse.svg";
 import NetworkConfiguration from "@/components/NetworkConfiguration";
-import { Button } from "@canonical/react-components";
+import { Button, Notification } from "@canonical/react-components";
+import { checkBackendAvailable } from "@/utils/checkBackendAvailable";
+
 
 export default function Home() {
   const views = ["network configuration", "subscribers", "network slices"];
   const [view, setView] = useState<string>(views[0]);
+  const [backendAvailable, setBackendAvailable] = useState(false);
+
 
   const handleViewNetworkConfiguration = () => {
     setView(views[0]);
@@ -18,10 +21,22 @@ export default function Home() {
   const handleViewSubscribers = () => {
     setView(views[1]);
   };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const isBackendAvailable = await checkBackendAvailable();
+      setBackendAvailable(isBackendAvailable);
+    };
+
+    fetchData();
+  }, []);
+
+
   return (
     <main className="flex min-h-screen flex-col items-start justify-start">
       <div className="grid grid-cols-12">
         <nav className="fixed col-span-2 flex h-screen flex-col items-start bg-[#333]">
+        
           <Image
             src={canonicalUbuntuLogo}
             priority={true}
@@ -45,10 +60,18 @@ export default function Home() {
           </Button>
         </nav>
         <div className="col-span-12 ml-[16rem] mt-8 flex w-10/12 flex-col items-start">
-          {view == views[0] && <NetworkConfiguration />}
-          {view == views[1] && <SubscriberTable />}
+
+          {!backendAvailable && (
+            <Notification severity="negative" title="Error">
+              {"Backend not available"}
+            </Notification>
+          )}
+
+          {backendAvailable && view === views[0] && <NetworkConfiguration />}
+          {backendAvailable && view === views[1] && <SubscriberTable />}
         </div>
       </div>
     </main>
-  );
+);
+
 }

--- a/utils/checkBackendAvailable.tsx
+++ b/utils/checkBackendAvailable.tsx
@@ -1,0 +1,14 @@
+export const checkBackendAvailable = async () => {
+    try {
+      const response = await fetch(`/api/getSubscribers`);
+  
+      if (response.status === 200) {
+        return true;
+      } else {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+  };
+  


### PR DESCRIPTION
# Description

This PR will make it so that the gui content will only be rendered if the backend is available. If it isn't, a notification will show up instead.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
